### PR TITLE
Fix BLESyncManager Message Leak Issue

### DIFF
--- a/test-sync-watch/src/main/java/com/example/test_sync/MainActivity.kt
+++ b/test-sync-watch/src/main/java/com/example/test_sync/MainActivity.kt
@@ -38,12 +38,12 @@ class MainActivity : ComponentActivity() {
 
         super.onCreate(savedInstanceState)
         syncManager.addOnReceivedListener(setOf("test")) { key, json ->
-            Log.v("test", json.toString())
+            Log.v("WATCH_RECEIVED", "Received from phone: $json")
         }
 
         syncManager.addOnReceivedListener(setOf("test2")) { key, json ->
             val testData: TestData = Json.decodeFromJsonElement(json)
-            Log.v("test2", testData.toString())
+            Log.v("WATCH_RECEIVED", "Received TestData from phone: $testData")
         }
 
         setTheme(android.R.style.Theme_DeviceDefault)
@@ -52,6 +52,7 @@ class MainActivity : ComponentActivity() {
             WearApp(
                 sendText = {
                     CoroutineScope(Dispatchers.IO).launch {
+                        Log.d("WATCH_SENDING", "Sending text to phone: HELLO")
                         syncManager.send(
                             "test",
                             "HELLO"
@@ -60,12 +61,11 @@ class MainActivity : ComponentActivity() {
                 },
                 sendData = {
                     CoroutineScope(Dispatchers.IO).launch {
+                        val testData = TestData(test = "HELLO-FROM-WATCH", test2 = 123)
+                        Log.d("WATCH_SENDING", "Sending TestData to phone: $testData")
                         syncManager.send(
                             "test2",
-                            TestData(
-                                test = "HELLO",
-                                test2 = 123
-                            )
+                            testData
                         )
                     }
                 }

--- a/test-sync-watch/src/main/java/com/example/test_sync/MainActivity.kt
+++ b/test-sync-watch/src/main/java/com/example/test_sync/MainActivity.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.decodeFromJsonElement
 
 @Serializable

--- a/test-sync-watch/src/main/java/com/example/test_sync/MainActivity.kt
+++ b/test-sync-watch/src/main/java/com/example/test_sync/MainActivity.kt
@@ -51,7 +51,6 @@ class MainActivity : ComponentActivity() {
             WearApp(
                 sendText = {
                     CoroutineScope(Dispatchers.IO).launch {
-                        Log.d("WATCH_SENDING", "Sending text to phone: HELLO")
                         syncManager.send(
                             "test",
                             "HELLO"
@@ -61,7 +60,6 @@ class MainActivity : ComponentActivity() {
                 sendData = {
                     CoroutineScope(Dispatchers.IO).launch {
                         val testData = TestData(test = "HELLO-FROM-WATCH", test2 = 123)
-                        Log.d("WATCH_SENDING", "Sending TestData to phone: $testData")
                         syncManager.send(
                             "test2",
                             testData

--- a/test-sync-watch/src/main/java/com/example/test_sync/MainActivity.kt
+++ b/test-sync-watch/src/main/java/com/example/test_sync/MainActivity.kt
@@ -37,12 +37,12 @@ class MainActivity : ComponentActivity() {
 
         super.onCreate(savedInstanceState)
         syncManager.addOnReceivedListener(setOf("test")) { key, json ->
-            Log.v("WATCH_RECEIVED", "Received from phone: $json")
+            Log.v("WATCH_RECEIVED", "Received From Phone: $json")
         }
 
         syncManager.addOnReceivedListener(setOf("test2")) { key, json ->
             val testData: TestData = Json.decodeFromJsonElement(json)
-            Log.v("WATCH_RECEIVED", "Received TestData from phone: $testData")
+            Log.v("WATCH_RECEIVED", "Received TestData From Phone: $testData")
         }
 
         setTheme(android.R.style.Theme_DeviceDefault)
@@ -59,7 +59,7 @@ class MainActivity : ComponentActivity() {
                 },
                 sendData = {
                     CoroutineScope(Dispatchers.IO).launch {
-                        val testData = TestData(test = "HELLO-FROM-WATCH", test2 = 123)
+                        val testData = TestData(test = "HELLO_FROM_WATCH", test2 = 123)
                         syncManager.send(
                             "test2",
                             testData

--- a/test-sync/src/main/java/com/example/test_sync/MainActivity.kt
+++ b/test-sync/src/main/java/com/example/test_sync/MainActivity.kt
@@ -54,7 +54,10 @@ class MainActivity : ComponentActivity() {
                         Button(
                             onClick = {
                                 CoroutineScope(Dispatchers.IO).launch {
-                                    Log.d("PHONE_SENDING", "Sending text to watch: HELLO-FROM-PHONE")
+                                    Log.d(
+                                        "PHONE_SENDING",
+                                        "Sending text to watch: HELLO-FROM-PHONE"
+                                    )
                                     syncManager.send(
                                         "test",
                                         "HELLO-FROM-PHONE"
@@ -101,8 +104,14 @@ class MainActivity : ComponentActivity() {
                         Button(
                             onClick = {
                                 CoroutineScope(Dispatchers.IO).launch {
-                                    val testData = TestData(test = "HELLO-FROM-PHONE", test2 = (System.currentTimeMillis() / 1000).toInt())
-                                    Log.d("PHONE_SENDING", "Sending TestData with timestamp to watch: $testData")
+                                    val testData = TestData(
+                                        test = "HELLO-FROM-PHONE",
+                                        test2 = (System.currentTimeMillis() / 1000).toInt()
+                                    )
+                                    Log.d(
+                                        "PHONE_SENDING",
+                                        "Sending TestData with timestamp to watch: $testData"
+                                    )
                                     syncManager.send(
                                         "test2",
                                         testData

--- a/test-sync/src/main/java/com/example/test_sync/MainActivity.kt
+++ b/test-sync/src/main/java/com/example/test_sync/MainActivity.kt
@@ -54,10 +54,6 @@ class MainActivity : ComponentActivity() {
                         Button(
                             onClick = {
                                 CoroutineScope(Dispatchers.IO).launch {
-                                    Log.d(
-                                        "PHONE_SENDING",
-                                        "Sending text to watch: HELLO-FROM-PHONE"
-                                    )
                                     syncManager.send(
                                         "test",
                                         "HELLO-FROM-PHONE"
@@ -73,7 +69,6 @@ class MainActivity : ComponentActivity() {
                             onClick = {
                                 CoroutineScope(Dispatchers.IO).launch {
                                     val testData = TestData(test = "HELLO-FROM-PHONE", test2 = 123)
-                                    Log.d("PHONE_SENDING", "Sending TestData to watch: $testData")
                                     syncManager.send(
                                         "test2",
                                         testData
@@ -89,7 +84,6 @@ class MainActivity : ComponentActivity() {
                             onClick = {
                                 CoroutineScope(Dispatchers.IO).launch {
                                     val testData = TestData(test = "HELLO-FROM-PHONE", test2 = 456)
-                                    Log.d("PHONE_SENDING", "Sending TestData to watch: $testData")
                                     syncManager.send(
                                         "test2",
                                         testData
@@ -107,10 +101,6 @@ class MainActivity : ComponentActivity() {
                                     val testData = TestData(
                                         test = "HELLO-FROM-PHONE",
                                         test2 = (System.currentTimeMillis() / 1000).toInt()
-                                    )
-                                    Log.d(
-                                        "PHONE_SENDING",
-                                        "Sending TestData with timestamp to watch: $testData"
                                     )
                                     syncManager.send(
                                         "test2",

--- a/test-sync/src/main/java/com/example/test_sync/MainActivity.kt
+++ b/test-sync/src/main/java/com/example/test_sync/MainActivity.kt
@@ -35,12 +35,12 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         syncManager.addOnReceivedListener(setOf("test")) { key, json ->
-            Log.v("test", json.toString())
+            Log.v("PHONE_RECEIVED", "Received from watch: $json")
         }
 
         syncManager.addOnReceivedListener(setOf("test2")) { key, json ->
             val testData: TestData = Json.decodeFromJsonElement(json)
-            Log.v("test2", testData.toString())
+            Log.v("PHONE_RECEIVED", "Received TestData from watch: $testData")
         }
 
         enableEdgeToEdge()
@@ -55,9 +55,10 @@ class MainActivity : ComponentActivity() {
                         Button(
                             onClick = {
                                 CoroutineScope(Dispatchers.IO).launch {
+                                    Log.d("PHONE_SENDING", "Sending text to watch: HELLO7")
                                     syncManager.send(
                                         "test",
-                                        "HELLO7"
+                                        "HELLO-FROM-PHONE"
                                     )
                                 }
                             },
@@ -69,12 +70,11 @@ class MainActivity : ComponentActivity() {
                         Button(
                             onClick = {
                                 CoroutineScope(Dispatchers.IO).launch {
+                                    val testData = TestData(test = "HELLO-FROM-PHONE", test2 = 123)
+                                    Log.d("PHONE_SENDING", "Sending TestData to watch: $testData")
                                     syncManager.send(
                                         "test2",
-                                        TestData(
-                                            test = "HELLO",
-                                            test2 = 123
-                                        )
+                                        testData
                                     )
                                 }
                             },
@@ -86,12 +86,11 @@ class MainActivity : ComponentActivity() {
                         Button(
                             onClick = {
                                 CoroutineScope(Dispatchers.IO).launch {
+                                    val testData = TestData(test = "HELLO-FROM-PHONE", test2 = 456)
+                                    Log.d("PHONE_SENDING", "Sending TestData to watch: $testData")
                                     syncManager.send(
                                         "test2",
-                                        TestData(
-                                            test = "Bye",
-                                            test2 = 456
-                                        )
+                                        testData
                                     )
                                 }
                             },
@@ -103,12 +102,11 @@ class MainActivity : ComponentActivity() {
                         Button(
                             onClick = {
                                 CoroutineScope(Dispatchers.IO).launch {
+                                    val testData = TestData(test = "HELLO-FROM-PHONE", test2 = (System.currentTimeMillis() / 1000).toInt())
+                                    Log.d("PHONE_SENDING", "Sending TestData with timestamp to watch: $testData")
                                     syncManager.send(
                                         "test2",
-                                        TestData(
-                                            test = "Bye",
-                                            test2 = (System.currentTimeMillis() / 1000).toInt()
-                                        )
+                                        testData
                                     )
                                 }
                             },

--- a/test-sync/src/main/java/com/example/test_sync/MainActivity.kt
+++ b/test-sync/src/main/java/com/example/test_sync/MainActivity.kt
@@ -34,12 +34,12 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         syncManager.addOnReceivedListener(setOf("test")) { key, json ->
-            Log.v("PHONE_RECEIVED", "Received from watch: $json")
+            Log.v("PHONE_RECEIVED", "Received From Watch: $json")
         }
 
         syncManager.addOnReceivedListener(setOf("test2")) { key, json ->
             val testData: TestData = Json.decodeFromJsonElement(json)
-            Log.v("PHONE_RECEIVED", "Received TestData from watch: $testData")
+            Log.v("PHONE_RECEIVED", "Received TestData From Watch: $testData")
         }
 
         enableEdgeToEdge()
@@ -56,7 +56,7 @@ class MainActivity : ComponentActivity() {
                                 CoroutineScope(Dispatchers.IO).launch {
                                     syncManager.send(
                                         "test",
-                                        "HELLO-FROM-PHONE"
+                                        "HELLO_FROM_PHONE"
                                     )
                                 }
                             },
@@ -68,7 +68,7 @@ class MainActivity : ComponentActivity() {
                         Button(
                             onClick = {
                                 CoroutineScope(Dispatchers.IO).launch {
-                                    val testData = TestData(test = "HELLO-FROM-PHONE", test2 = 123)
+                                    val testData = TestData(test = "HELLO_FROM_PHONE", test2 = 123)
                                     syncManager.send(
                                         "test2",
                                         testData
@@ -83,7 +83,7 @@ class MainActivity : ComponentActivity() {
                         Button(
                             onClick = {
                                 CoroutineScope(Dispatchers.IO).launch {
-                                    val testData = TestData(test = "HELLO-FROM-PHONE", test2 = 456)
+                                    val testData = TestData(test = "HELLO_FROM_PHONE", test2 = 456)
                                     syncManager.send(
                                         "test2",
                                         testData
@@ -99,7 +99,7 @@ class MainActivity : ComponentActivity() {
                             onClick = {
                                 CoroutineScope(Dispatchers.IO).launch {
                                     val testData = TestData(
-                                        test = "HELLO-FROM-PHONE",
+                                        test = "HELLO_FROM_PHONE",
                                         test2 = (System.currentTimeMillis() / 1000).toInt()
                                     )
                                     syncManager.send(

--- a/test-sync/src/main/java/com/example/test_sync/MainActivity.kt
+++ b/test-sync/src/main/java/com/example/test_sync/MainActivity.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.decodeFromJsonElement
 
 @Serializable
@@ -55,7 +54,7 @@ class MainActivity : ComponentActivity() {
                         Button(
                             onClick = {
                                 CoroutineScope(Dispatchers.IO).launch {
-                                    Log.d("PHONE_SENDING", "Sending text to watch: HELLO7")
+                                    Log.d("PHONE_SENDING", "Sending text to watch: HELLO-FROM-PHONE")
                                     syncManager.send(
                                         "test",
                                         "HELLO-FROM-PHONE"


### PR DESCRIPTION
Fix BLESyncManager Message Leak Issue:

There is an issue where the message sender receive it's own message that supposedly being sent to the receiver.
For example:
Phone send text "Hello From Phone" -> Watch receives "Hello From Phone"
However, the sender (phone) also receives message input "Hello From Phone".

This is unexpected because the sender supposed only to receive messages that it receives. So in this PR, there is a fix for that issue by initialize the local node id, and ignore the message if the message comes from the local node id

Other Improvements:
- Rename the message log to make it more understandable