### PR TITLE
Add Token Refresh Error Catching & Enable WakeLocks to Prevent Silent Data Drops

### DIFF
--- a/app-mobile-tracker/src/main/AndroidManifest.xml
+++ b/app-mobile-tracker/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission
         android:name="android.permission.FOREGROUND_SERVICE"
         tools:ignore="ForegroundServicesPolicy" />

--- a/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/PhoneSensorDataService.kt
+++ b/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/PhoneSensorDataService.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
+import android.os.PowerManager
 import android.util.Log
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
@@ -209,6 +210,16 @@ class PhoneSensorDataService : LifecycleService(), KoinComponent {
         }
     }
 
+    private var wakeLock: PowerManager.WakeLock? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
+        wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "$TAG::WakeLock")
+        wakeLock?.acquire()
+        Log.d(TAG, "WakeLock acquired")
+    }
+
     override fun onDestroy() {
         // Only remove if we registered
         if (listenersRegistered) {
@@ -231,6 +242,13 @@ class PhoneSensorDataService : LifecycleService(), KoinComponent {
             }
             if (flushed == null) {
                 Log.w(TAG, "onDestroy flush timed out after 3s — some buffered data may be lost")
+            }
+        }
+        
+        wakeLock?.let {
+            if (it.isHeld) {
+                it.release()
+                Log.d(TAG, "WakeLock released")
             }
         }
 

--- a/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/SurveyService.kt
+++ b/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/SurveyService.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import io.github.jan.supabase.auth.auth
+import kotlinx.coroutines.CancellationException
 
 /**
  * Service for fetching survey configuration from Supabase
@@ -218,7 +219,7 @@ class SurveyService(
                     Unit
                 }
             } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
+                if (e is CancellationException) throw e
                 Log.e(TAG, "Failed to refresh session or retry upload: ${e.message}", e)
             }
         }

--- a/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/SurveyService.kt
+++ b/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/SurveyService.kt
@@ -10,6 +10,7 @@ import kaist.iclab.mobiletracker.data.survey.SurveyQuestionResponseInsert
 import kaist.iclab.mobiletracker.data.survey.SurveyQuestionTriggerEntity
 import kaist.iclab.mobiletracker.db.obx.MicroEmaResponseStore
 import kaist.iclab.mobiletracker.helpers.SupabaseHelper
+import kaist.iclab.mobiletracker.repository.AppError
 import kaist.iclab.mobiletracker.repository.ErrorClassifier
 import kaist.iclab.mobiletracker.repository.Result
 import kaist.iclab.mobiletracker.repository.runCatchingSuspend

--- a/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/SurveyService.kt
+++ b/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/SurveyService.kt
@@ -22,6 +22,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
+import io.github.jan.supabase.auth.auth
 
 /**
  * Service for fetching survey configuration from Supabase
@@ -201,9 +202,27 @@ class SurveyService(
      * Directly inserts a list of survey responses into the Supabase 'survey_question_response' table.
      */
     suspend fun submitSurveyResponses(responses: List<SurveyQuestionResponseInsert>): Result<Unit> {
-        return ErrorClassifier.runClassified(TAG, "submitSurveyResponses") {
+        var result: Result<Unit> = ErrorClassifier.runClassified(TAG, "submitSurveyResponses") {
             supabaseClient.from(Constants.DB.TABLE_RESPONSE).insert(responses)
+            Unit
         }
+
+        if (result is Result.Error && result.exception is AppError.Auth) {
+            Log.w(TAG, "Auth error during submitSurveyResponses, attempting to refresh session and retry")
+            try {
+                supabaseClient.auth.refreshCurrentSession()
+                Log.d(TAG, "Session refreshed successfully, retrying submitSurveyResponses")
+                result = ErrorClassifier.runClassified(TAG, "submitSurveyResponses (retry)") {
+                    supabaseClient.from(Constants.DB.TABLE_RESPONSE).insert(responses)
+                    Unit
+                }
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                Log.e(TAG, "Failed to refresh session or retry upload: ${e.message}", e)
+            }
+        }
+        
+        return result
     }
 
     /**

--- a/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/upload/SensorUploadService.kt
+++ b/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/upload/SensorUploadService.kt
@@ -101,25 +101,50 @@ class SensorUploadService(
             Constants.Network.QUARANTINE_AFTER_FAILED_UPLOAD_CYCLES
 
         return try {
+            val onBatchUploadedImpl: suspend (Long) -> Unit = { cursor ->
+                syncTimestampService.setUploadCursor(sensorId, cursor)
+                syncTimestampService.addUploadStats(sensorId, succeededBatches = 1)
+                onBatchUploaded()
+            }
+
+            val onBatchQuarantinedImpl: suspend (Long, Int, String) -> Unit = { cursor, recordCount, reason ->
+                syncTimestampService.setUploadCursor(sensorId, cursor)
+                syncTimestampService.addUploadStats(sensorId, quarantinedRecordCount = recordCount)
+                Log.w(TAG, "Gave up on $recordCount $sensorId record(s) up to cursor $cursor: $reason")
+                onBatchUploaded()
+            }
+
             // Persist the cursor as each batch lands rather than only once the sensor finishes, so
             // an error part-way through a large backlog keeps the batches that already reached
             // Supabase instead of re-uploading them on every retry.
-            val result = handler.uploadData(
+            var result = handler.uploadData(
                 userUuid,
-                lastUploadCursor,
+                syncTimestampService.getUploadCursor(sensorId),
                 allowQuarantine = allowQuarantine,
-                onBatchUploaded = { cursor ->
-                    syncTimestampService.setUploadCursor(sensorId, cursor)
-                    syncTimestampService.addUploadStats(sensorId, succeededBatches = 1)
-                    onBatchUploaded()
-                },
-                onBatchQuarantined = { cursor, recordCount, reason ->
-                    syncTimestampService.setUploadCursor(sensorId, cursor)
-                    syncTimestampService.addUploadStats(sensorId, quarantinedRecordCount = recordCount)
-                    Log.w(TAG, "Gave up on $recordCount $sensorId record(s) up to cursor $cursor: $reason")
-                    onBatchUploaded()
-                }
+                onBatchUploaded = onBatchUploadedImpl,
+                onBatchQuarantined = onBatchQuarantinedImpl
             )
+
+            // If the upload failed due to an expired token (RLS 401), attempt to refresh the session and retry
+            if (result is Result.Error && result.exception is AppError.Auth) {
+                Log.w(TAG, "Auth error during upload for $sensorId, attempting to refresh session and retry")
+                try {
+                    supabaseHelper.supabaseClient.auth.refreshCurrentSession()
+                    Log.d(TAG, "Session refreshed successfully, retrying upload")
+                    
+                    // Retry with the latest cursor (in case some batches succeeded before the auth error)
+                    result = handler.uploadData(
+                        userUuid,
+                        syncTimestampService.getUploadCursor(sensorId),
+                        allowQuarantine = allowQuarantine,
+                        onBatchUploaded = onBatchUploadedImpl,
+                        onBatchQuarantined = onBatchQuarantinedImpl
+                    )
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    Log.e(TAG, "Failed to refresh session or retry upload: ${e.message}", e)
+                }
+            }
 
             // Records this call actually moved past, whether uploaded or quarantined: the cursor
             // is a local row id and this app never prunes data, so its delta over the call is the

--- a/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/upload/SurveyResponseUploader.kt
+++ b/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/upload/SurveyResponseUploader.kt
@@ -67,7 +67,7 @@ class SurveyResponseUploader(
             return@withLock Result.Success(0)
         }
 
-        ErrorClassifier.runClassified(TAG, "upload survey responses") {
+        var result = ErrorClassifier.runClassified(TAG, "Upload survey responses") {
             val batchSize = Constants.Network.UPLOAD_BATCH_SIZE
             var uploaded = 0
 
@@ -97,6 +97,50 @@ class SurveyResponseUploader(
             Log.d(TAG, "Uploaded $uploaded survey response rows")
             uploaded
         }
+
+        if (result is Result.Error && result.exception is AppError.Auth) {
+            Log.w(TAG, "Auth error during upload, attempting to refresh session and retry")
+            try {
+                supabaseHelper.supabaseClient.auth.refreshCurrentSession()
+                Log.d(TAG, "Session refreshed successfully, retrying upload")
+
+                result = ErrorClassifier.runClassified(TAG, "upload survey responses (retry)") {
+                    val batchSize = Constants.Network.UPLOAD_BATCH_SIZE
+                    var uploaded = 0
+
+                    while (true) {
+                        val batch = store.unsynced(batchSize.toLong())
+                        if (batch.isEmpty()) break
+
+                        val rows = batch.map { entity ->
+                            SurveyQuestionResponseInsert(
+                                questionId = entity.questionId,
+                                uuid = userUuid,
+                                triggerTime = DateTimeFormatter.formatToIsoOffset(entity.triggerTime),
+                                actualTriggerTime = DateTimeFormatter.formatToIsoOffset(entity.actualTriggerTime),
+                                surveyStartTime = DateTimeFormatter.formatToIsoOffset(entity.surveyStartTime),
+                                responseSubmissionTime = DateTimeFormatter.formatToIsoOffset(entity.responseSubmissionTime),
+                                response = Json.parseToJsonElement(entity.responseJson)
+                            )
+                        }
+                        supabaseHelper.supabaseClient.from(Constants.DB.TABLE_RESPONSE).insert(rows)
+
+                        store.markSynced(batch.map { it.id })
+                        uploaded += batch.size
+
+                        if (batch.size < batchSize) break
+                    }
+
+                    Log.d(TAG, "Uploaded $uploaded survey response rows on retry")
+                    uploaded
+                }
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                Log.e(TAG, "Failed to refresh session or retry upload: ${e.message}", e)
+            }
+        }
+
+        return@withLock result
     }
 
     private fun getUserUuid(): String? {

--- a/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/upload/SurveyResponseUploader.kt
+++ b/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/upload/SurveyResponseUploader.kt
@@ -16,6 +16,7 @@ import kaist.iclab.mobiletracker.utils.SupabaseSessionHelper
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
 
 /**
@@ -136,7 +137,7 @@ class SurveyResponseUploader(
                     uploaded
                 }
             } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
+                if (e is CancellationException) throw e
                 Log.e(TAG, "Failed to refresh session or retry upload: ${e.message}", e)
             }
         }

--- a/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/upload/SurveyResponseUploader.kt
+++ b/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/upload/SurveyResponseUploader.kt
@@ -7,6 +7,7 @@ import kaist.iclab.mobiletracker.Constants
 import kaist.iclab.mobiletracker.data.survey.SurveyQuestionResponseInsert
 import kaist.iclab.mobiletracker.db.obx.SurveyResponseStore
 import kaist.iclab.mobiletracker.helpers.SupabaseHelper
+import kaist.iclab.mobiletracker.repository.AppError
 import kaist.iclab.mobiletracker.repository.ErrorClassifier
 import kaist.iclab.mobiletracker.repository.Result
 import kaist.iclab.mobiletracker.services.SyncTimestampService

--- a/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/upload/WebAppLogUploader.kt
+++ b/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/upload/WebAppLogUploader.kt
@@ -17,6 +17,7 @@ import kaist.iclab.mobiletracker.utils.SupabaseSessionHelper
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -147,7 +148,7 @@ class WebAppLogUploader(
                     uploaded
                 }
             } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
+                if (e is CancellationException) throw e
                 Log.e(TAG, "Failed to refresh session or retry upload: ${e.message}", e)
             }
         }

--- a/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/upload/WebAppLogUploader.kt
+++ b/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/upload/WebAppLogUploader.kt
@@ -9,6 +9,7 @@ import kaist.iclab.mobiletracker.db.obx.EpochMillisIsoSerializer
 import kaist.iclab.mobiletracker.db.obx.JsonStringElementSerializer
 import kaist.iclab.mobiletracker.db.obx.WebAppLogStore
 import kaist.iclab.mobiletracker.helpers.SupabaseHelper
+import kaist.iclab.mobiletracker.repository.AppError
 import kaist.iclab.mobiletracker.repository.ErrorClassifier
 import kaist.iclab.mobiletracker.repository.Result
 import kaist.iclab.mobiletracker.services.SyncTimestampService
@@ -111,7 +112,7 @@ class WebAppLogUploader(
             uploaded
         }
 
-        if (result is Result.Error && result.exception is kaist.iclab.mobiletracker.repository.AppError.Auth) {
+        if (result is Result.Error && result.exception is AppError.Auth) {
             Log.w(TAG, "Auth error during upload, attempting to refresh session and retry")
             try {
                 supabaseHelper.supabaseClient.auth.refreshCurrentSession()

--- a/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/upload/WebAppLogUploader.kt
+++ b/app-mobile-tracker/src/main/java/kaist/iclab/mobiletracker/services/upload/WebAppLogUploader.kt
@@ -82,7 +82,7 @@ class WebAppLogUploader(
             return@withLock Result.Success(0)
         }
 
-        ErrorClassifier.runClassified(TAG, "upload webapp logs") {
+        var result = ErrorClassifier.runClassified(TAG, "upload webapp logs") {
             val batchSize = Constants.Network.UPLOAD_BATCH_SIZE
             var uploaded = 0
 
@@ -110,6 +110,48 @@ class WebAppLogUploader(
             Log.d(TAG, "Uploaded $uploaded webapp log rows")
             uploaded
         }
+
+        if (result is Result.Error && result.exception is kaist.iclab.mobiletracker.repository.AppError.Auth) {
+            Log.w(TAG, "Auth error during upload, attempting to refresh session and retry")
+            try {
+                supabaseHelper.supabaseClient.auth.refreshCurrentSession()
+                Log.d(TAG, "Session refreshed successfully, retrying upload")
+                
+                result = ErrorClassifier.runClassified(TAG, "upload webapp logs (retry)") {
+                    val batchSize = Constants.Network.UPLOAD_BATCH_SIZE
+                    var uploaded = 0
+
+                    while (true) {
+                        val batch = store.unsynced(batchSize.toLong())
+                        if (batch.isEmpty()) break
+
+                        val rows = batch.map { entity ->
+                            WebAppLogRow(
+                                uuid = userUuid,
+                                timestamp = entity.timestamp,
+                                webAppId = entity.webAppId,
+                                eventType = entity.eventType,
+                                properties = entity.propertiesJson
+                            )
+                        }
+                        supabaseHelper.supabaseClient.from(AppConfig.SupabaseTables.WEB_APP_LOG).insert(rows)
+
+                        store.markSynced(batch.map { it.id })
+                        uploaded += batch.size
+
+                        if (batch.size < batchSize) break
+                    }
+
+                    Log.d(TAG, "Uploaded $uploaded webapp log rows on retry")
+                    uploaded
+                }
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                Log.e(TAG, "Failed to refresh session or retry upload: ${e.message}", e)
+            }
+        }
+        
+        return@withLock result
     }
 
     private fun getUserUuid(): String? {


### PR DESCRIPTION
Fix Several Aspects

**1. Token Expiration & RLS Failures recovery**
Since enableLifecycleCallbacks = false is used in SupabaseHelper (to prevent SDK background lifecycle crashes), auto-refresh of the Supabase auth token ceases in the background. After a few hours, the token expires, resulting in AppError.Auth (401 Unauthorized) and RLS failures during background uploads.

**2. CPU Suspension (Missing WakeLocks)**
When the phone screen is off and deep sleep states are active, the background foreground service can experience CPU throttling or temporary suspension, causing the possible silent data drops in sensor sampling.